### PR TITLE
Calculated block number for MIFARE Classic 4k cards incorrect.

### DIFF
--- a/miLazyCracker.sh
+++ b/miLazyCracker.sh
@@ -82,6 +82,12 @@ while [ $keepTrying -eq 1 ]; do
             unknownKeyLetter=${arr[4]}
             knownBlockNum=$((knownSectorNum * 4))
             unknownBlockNum=$((unknownSectorNum * 4))
+            if [ "$knownSectorNum" -gt 31 ]; then
+                knownBlockNum=$((128+((knownSectorNum-32)*16)))
+            fi
+            if [ "$unknownSectorNum" -gt 31 ]; then
+                unknownBlockNum=$((128+((unknownSectorNum-32)*16)))
+            fi
             echo "Trying HardNested Attack..."
             mycmd=(libnfc_crypto1_crack "$knownKey" "$knownBlockNum" "$knownKeyLetter" "$unknownBlockNum" "$unknownKeyLetter" "$TMPFILE_FND")
             echo "${mycmd[@]}"


### PR DESCRIPTION
MIFARE Classic 4k cards have a different memory structure to 1k cards:

- In 1k cards, all sectors are 4 blocks.
- In 4k cards, the first 32 sectors are 4 blocks, but the last 8 are 16 blocks.

This is just a fix so that the two block numbers calculated by the script are correct if the card is a 4k card.

See §2.2 of [this](http://www.cs.ru.nl/~flaviog/publications/Attack.MIFARE.pdf) paper for details.