### PR TITLE
Can we enable github issues?

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,3 @@ This tool is comprised of work from:
 -  MFOC - https://github.com/nfc-tools/mfoc
 
 -  MFCUK - https://github.com/nfc-tools/mfcuk
-


### PR DESCRIPTION
As this is probably the most used fork of miLazyCracker I think it would be a good idea to enable github issues for this repository here as they are disabled in ilumitr/miLazyCracker.