### PR TITLE
Fix gcc-10 linker error

### DIFF
--- a/crypto1_bs.diff
+++ b/crypto1_bs.diff
@@ -1,5 +1,18 @@
+diff --git a/Makefile b/Makefile
+index 758e411..c0708be 100755
+--- a/Makefile
++++ b/Makefile
+@@ -7,7 +7,7 @@
+ 
+ CC     = gcc
+ 
+-CFLAGS = -std=gnu99 -O3 -march=native
++CFLAGS = -std=gnu99 -O3 -march=native -fcommon
+ 
+ all: solve_bs solve_piwi_bs solve_piwi libnfc_crypto1_crack
+ 
 diff --git a/libnfc_crypto1_crack.c b/libnfc_crypto1_crack.c
-index 2015dcb..0fa7436 100755
+index 2015dcb..4147433 100755
 --- a/libnfc_crypto1_crack.c
 +++ b/libnfc_crypto1_crack.c
 @@ -730,6 +730,17 @@ int main (int argc, const char * argv[]) {


### PR DESCRIPTION
gcc-10 default to -fno-common, which cause build break
Add -fcommon flag to solve this problem