### PR TITLE
Fix of patch of miLazyCracker + github actions + docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Check build script
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "master" branch
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: ./miLazyCrackerFreshInstall.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: Create and publish a Docker image
+
+on:
+  # Triggers the workflow on push or pull request events but only for the "master" branch
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: docker
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            REPO=https://github.com/${{github.repository}}

--- a/crypto1_bs.diff
+++ b/crypto1_bs.diff
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index 758e411..c0708be 100755
+index c52e87b..575ffea 100755
 --- a/Makefile
 +++ b/Makefile
 @@ -7,7 +7,7 @@
@@ -8,9 +8,9 @@ index 758e411..c0708be 100755
  
 -CFLAGS = -std=gnu99 -O3 -march=native
 +CFLAGS = -std=gnu99 -O3 -march=native -fcommon
+ LDFLAGS=  -Wl,--allow-multiple-definition
  
  all: solve_bs solve_piwi_bs solve_piwi libnfc_crypto1_crack
- 
 diff --git a/libnfc_crypto1_crack.c b/libnfc_crypto1_crack.c
 index 2015dcb..4147433 100755
 --- a/libnfc_crypto1_crack.c

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM kalilinux/kali-rolling
+ARG REPO=https://github.com/orensbruli/miLazyCracker
+RUN apt update && apt install wget sudo make autoconf pkg-config gcc git mfcuk xz-utils  -y
+RUN git clone $REPO
+RUN cd miLazyCracker && bash -x miLazyCrackerFreshInstall.sh
+ENTRYPOINT ["miLazyCracker"]
+

--- a/miLazyCrackerFreshInstall.sh
+++ b/miLazyCrackerFreshInstall.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # try to get craptev1-v1.1.tar.xz and crapto1-v3.3.tar.xz
 # 2550aa92fcb504b62dbc4a978c51d283f34ed2d393ea0c55444dc4bf5cd3c4e4  craptev1-v1.1.tar.xz
@@ -22,7 +23,7 @@ if [ -f "/etc/debian_version" ]; then
         fi
     done
     if [ "$pkgs" != "" ]; then
-        sudo apt-get install $pkgs
+        sudo apt-get install $pkgs -y || true
     fi
 fi
 


### PR DESCRIPTION
It fixes the current problem with the saved patch that does not match the source code anymore.
Also added minor changes to the fresh install script to make it more automatic and able to test in GitHub actions.
Also added an action to build a docker image based on kali Linux.
With this image miLazyCracker could  be executed like this:
`docker run --privileged -v /dev/bus/usb:/dev/bus/usb ghcr.io/nfc-tools/milazycracker:master`
So, only docker would be needed and no other installation.